### PR TITLE
Utilizing Browserify's noParse to speed up builds

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -9,7 +9,13 @@ var browserify = require('browserify'),
 
 module.exports = function (gulp, config) {
   gulp.task('browserify', function () {
-    return browserify('./' + config.src.root + '/main.js')
+    var options = {};
+
+    if (config.hasOwnProperty('browserify') && config.browserify.hasOwnProperty('noParse')) {
+      options.noParse = config.browserify.noParse;
+    }
+
+    return browserify('./' + config.src.root + '/main.js', options)
       .bundle()
       .pipe(source(config.src.root + '/main.js'))
       .pipe(buffer())


### PR DESCRIPTION
Let's not parse for `require()` statements in modules we know will not have them. This makes browserify run much faster.

Teammate before:
![before](https://cloud.githubusercontent.com/assets/164472/7745065/5e7891e0-ff76-11e4-819f-ed6aaef0e7b4.png)

Teammate after:
![after](https://cloud.githubusercontent.com/assets/164472/7745069/638943f0-ff76-11e4-8777-b7d879607b35.png)
