### PR TITLE
Speed up copy by not reading the files

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -5,11 +5,11 @@ module.exports = function (gulp, config) {
     return gulp.src([
       'node_modules/bootstrap-sass/assets/fonts/bootstrap/*.{ttf,woff,woff2,svg,eot}',
       'node_modules/uniform/assets/fonts/*'
-    ]).pipe(gulp.dest(config.dist.root + '/fonts'));
+    ], {read:false}).pipe(gulp.dest(config.dist.root + '/fonts'));
   });
 
   gulp.task('copy-images', ['clean'], function () {
-    return gulp.src(config.src.root + '/img/*.{png,gif,jpg}')
+    return gulp.src(config.src.root + '/img/*.{png,gif,jpg}', {read:false})
       .pipe(gulp.dest(config.dist.root + '/img'));
   });
 


### PR DESCRIPTION
We can speed up the copying of assets, especially large font files, but telling Gulp not to read the files as it copies them.

Before:
![before2](https://cloud.githubusercontent.com/assets/164472/7745357/8dd5c5f0-ff78-11e4-800e-6dd598c90cff.png)

After:
![after2](https://cloud.githubusercontent.com/assets/164472/7745364/960c6bb6-ff78-11e4-8518-7835fab95012.png)
