### PR TITLE
Handle building test environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "plumber": "^0.4.8",
     "require-dir": "^0.3.0",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.0.0"
+    "vinyl-source-stream": "^1.0.0",
+    "yargs": "^3.24.0"
   }
 }

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var browserify = require('browserify'),
+var argv = require('yargs').argv,
+  browserify = require('browserify'),
   buffer = require('vinyl-buffer'),
   gutil = require('gulp-util'),
   rename = require('gulp-rename'),
@@ -15,9 +16,15 @@ module.exports = function (gulp, config) {
       options.noParse = config.browserify.noParse;
     }
 
-    return browserify('./' + config.src.root + '/main.js', options)
+    var mainjs = config.environment.dev.mainjs;
+
+    if (argv.test) {
+      mainjs = config.environment.test.mainjs;
+    }
+
+    return browserify('./' + mainjs, options)
       .bundle()
-      .pipe(source(config.src.root + '/main.js'))
+      .pipe(source(mainjs))
       .pipe(buffer())
       .pipe(rename(function (path) {
         path.dirname = ''; //strip the src path


### PR DESCRIPTION
Added a concept of development and test environments. Passing
`--test` to any gulp task that runs browserify will include a main
file specified by the test environment.